### PR TITLE
adds user bound channels for sse notifications

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -1,2 +1,2 @@
-USE_MOCK_JWKS=true
+USE_MOCK_JWKS=false
 JWKS_URL=https://login.microsoftonline.com/ff930651-2670-491e-9a70-7847e7fbf8b7/discovery/v2.0/keys

--- a/api/internal/broker/broker.go
+++ b/api/internal/broker/broker.go
@@ -1,6 +1,7 @@
 package broker
 
 import (
+	"sse/internal/models"
 	"sse/internal/sse"
 
 	"github.com/gin-gonic/gin"
@@ -9,5 +10,7 @@ import (
 type Broker interface {
 	Stream(c *gin.Context)
 	Listen()
-	Notify(sse.Event)
+	NotifyAll(sse.Event)
+	NotifyUser(event sse.Event, user models.UserContext)
+	NotifyAllButUser(event sse.Event, user models.UserContext)
 }

--- a/api/internal/broker/factory.go
+++ b/api/internal/broker/factory.go
@@ -5,10 +5,12 @@ import "sse/internal/sse"
 func New() Broker {
 
 	broker := &ChannelBroker{
-		Notifier:       make(chan sse.Event, 1),
-		NewClients:     make(chan chan sse.Event),
-		ClosingClients: make(chan chan sse.Event),
-		Clients:        make(map[chan sse.Event]bool),
+		NotifierAll:        make(chan sse.Event, 1),
+		NotifierUser:       make(chan sse.UserBoundSseEvent, 1),
+		NotifierAllButUser: make(chan sse.UserBoundSseEvent, 1),
+		NewClients:         make(chan UserBoundSseChannel),
+		ClosingClients:     make(chan UserBoundSseChannel),
+		Clients:            make(map[UserBoundSseChannel]bool),
 	}
 
 	go broker.Listen()

--- a/api/internal/sse/sse.go
+++ b/api/internal/sse/sse.go
@@ -1,5 +1,7 @@
 package sse
 
+import "sse/internal/models"
+
 type EventType string
 
 const (
@@ -15,6 +17,11 @@ const (
 type Event struct {
 	EventType
 	Payload string
+}
+
+type UserBoundSseEvent struct {
+	Event Event
+	User  models.UserContext
 }
 
 const PayloadEmpty = "{}"

--- a/client/src/lib/questions.ts
+++ b/client/src/lib/questions.ts
@@ -10,6 +10,7 @@ export const sessionActive = writable(false)
 const unsub = eventSource.subscribe((eventSource) => {
 	if (eventSource) {
 		eventSource.addEventListener("new_question", (event) => {
+			console.log(event)
 			const data = JSON.parse(event.data)
 			questionAdded(data)
 		})


### PR DESCRIPTION
- notification channels are bound to a user
- the current user can be notified separately from other users, enables correct notify of owned and creator properties on question create, only the owner gets "owned" as true, other users get false, creator is only returned to other users when question was created as non-anonymous